### PR TITLE
Added aiiinotate to annotation servers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -339,6 +339,7 @@ Links to help you discover IIIF resources that have been shared, demonstrations 
 
 ### Annotation Servers
 
+- [aiiinotate](https://github.com/Aikon-platform/aiiinotate) - IIIF annotation server built for speed and scalability, based on NodeJS and MongoDB. Designed to handle massive quantities of annotations (>10M) produced by computer vision tools.
 - [annotot](https://github.com/PenguinParadigm/annotot) - Simple IIIF annotations mounted in a Ruby on Rails applications.
 - [CatchPy](https://github.com/nmaekawa/catchpy) - Django-based annotation server with support for Web Annotation and AnnotatorJS APIs, using JWT for auth. Originally developed for the AnnotationsX LTI tool, CatchPy also supports tagging and responses.
 - [Elucidate](https://github.com/dlcs/elucidate-server) - Java and Postgres annotation server.


### PR DESCRIPTION
Hi ! 

Thank you for maintaining this great list.

This is a pull request to document [`aiiinotate`](https://github.com/Aikon-platform/aiiinotate), an annotation server we have been building for a few months. It will be presented at the upcoming IIIF Conference 2026.

`aiiinotate` is an annotation server built for speed and scalabilty. It aims to handle large collections of annotations (~100M annotations) with short response times (<1s read times). 

It is built on NodeJS (using the Fastify Web framework) and MongoDB for the database collection.

To prove its scalability, a benchmark of [`aiiinotate`](https://github.com/Aikon-platform/aiiinotate) is currently being developped. It will time responses for Create-Write-Update-Delete operations, including routes for batch updates. 

`aiiinotate` is also fully integrated with Mirador 4, thanks to @Tetras-IIIF's [Mirador-annotation-editor](https://github.com/TETRAS-IIIF/mirador-annotation-editor), for which we contributed an annotation adapter.

`aiiinotate` is currently used in production by several instances of [AIKON](https://aikon-platform.github.io/), a platform providing computer vision tools for historians. One of our `aiiinotate` instances in production currently stores >500K annotations.

Thank you so much for your review !
I am available for any further questions.
Paul