### PR TITLE
Add Annosearch to Content Search API section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,7 @@ Tools and resources that provide functionality for presenting IIIF materials in 
 
 Libraries and applications that support the Content Search API.
 
+- [Annosearch](https://github.com/nationalarchives/annosearch) - TypeScript tool from The National Archives that indexes W3C Web Annotations from IIIF collections and annotation servers (e.g. Miiify) using Quickwit, exposing them via a IIIF Content Search 2.0 API endpoint.
 - [Blacklight IIIF Search](https://github.com/boston-library/blacklight_iiif_search) - Plugin that provides IIIF Content Search functionality for [Blacklight](https://github.com/projectblacklight/blacklight)-based Rails applications.
 - [Ocracoke](https://github.com/NCSU-Libraries/ocracoke) - Rails application to create, index, and search text from page images and provide results in IIIF Content Search API format.
 - [Whiiif](https://github.com/mbennett-uoe/whiiif) - Python/Flask/Solr application to index IIIF manifests alongside ALTO representations and provide a IIIF Content Search API endpoint.


### PR DESCRIPTION
Adds [Annosearch](https://github.com/nationalarchives/annosearch) by The National Archives to the Content Search API section.

Annosearch is a TypeScript tool that indexes W3C Web Annotations from IIIF collections and annotation servers using [Quickwit](https://quickwit.io), and exposes them via a IIIF Content Search 2.0 API endpoint. It supports ingestion directly from IIIF collections and servers such as Miiify.

Placed alphabetically before Blacklight IIIF Search.